### PR TITLE
Add artifact uploading to github on tag. #6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # This will supress any download for dependencies and plugins or upload messages which would clutter the console log.
   # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.
   MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true -e -X"
-  MAVEN_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
+  MAVEN_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository"
   MAVEN_SKIP_CHECKS_AND_DOCS: "-Dair.check.skip-all=true -Dmaven.javadoc.skip=true"
   MAVEN_FAST_INSTALL: "-DskipTests -Dair.check.skip-all=true -Dmaven.javadoc.skip=true -B -q -T C1"
   JAVA_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError -Djdk.net.URLClassPath.disableClassPathURLCheck=true"
@@ -45,3 +45,15 @@ jdk8:
     - ./mvnw -v
     - ./mvnw install $MAVEN_FAST_INSTALL -am
     - ./mvnw test $MAVEN_SKIP_CHECKS_AND_DOCS -B $TEST_FLAGS
+
+deploy_artifact:
+  image: openjdk:8
+  stage: deploy
+  script:
+    - ./mvnw package -DskipTests
+    - ./mvnw help:evaluate -N -Dexpression=project.version|grep -v '\['
+    - export PROJECT_VERSION=$(./mvnw help:evaluate -N -Dexpression=project.version|grep -v '\['); echo ${PROJECT_VERSION}
+    - mv target/presto-tiledb-${PROJECT_VERSION}.jar target/presto-tiledb-${CI_COMMIT_REF_NAME}.jar
+    - TRACE=1 ./ci/upload-github-release-asset.sh github_api_token=${GITHUB_TOKEN} owner=TileDB-Inc repo=TileDB-Presto tag=${CI_COMMIT_REF_NAME} filename=target/presto-tiledb-${CI_COMMIT_REF_NAME}.jar
+  only:
+    - tags

--- a/ci/upload-github-release-asset.sh
+++ b/ci/upload-github-release-asset.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Author: Stefan Buck
+# License: MIT
+# https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
+#
+#
+# This script accepts the following parameters:
+#
+# * owner
+# * repo
+# * tag
+# * filename
+# * github_api_token
+#
+# Script to upload a release asset using the GitHub API v3.
+#
+# Example:
+#
+# upload-github-release-asset.sh github_api_token=TOKEN owner=stefanbuck repo=playground tag=v0.1.0 filename=./build.zip
+#
+
+# Check dependencies.
+set -e
+xargs=$(which gxargs || which xargs)
+
+# Validate settings.
+[ "$TRACE" ] && set -x
+
+CONFIG=$@
+
+for line in $CONFIG; do
+  eval "$line"
+done
+
+# Define variables.
+GH_API="https://api.github.com"
+GH_REPO="$GH_API/repos/$owner/$repo"
+GH_TAGS="$GH_REPO/releases/tags/$tag"
+AUTH="Authorization: token $github_api_token"
+WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
+CURL_ARGS="-LJO#"
+
+if [[ "$tag" == 'LATEST' ]]; then
+  GH_TAGS="$GH_REPO/releases/latest"
+fi
+
+# Validate token.
+curl -o /dev/null -sH "$AUTH" $GH_REPO || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
+
+# Read asset tags.
+response=$(curl -sH "$AUTH" $GH_TAGS)
+id=
+# Get ID of the asset based on given filename.
+eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+if [ -z "$id" ]; then
+    # Create the release
+    response=$(curl -sH "$AUTH" $GH_REPO/releases -d '{"tag_name": '"\"${tag}\""', "name": '"\"${tag}\""', "body": "", "draft": false, "prerelease": false }');
+    echo $response;
+    eval $(echo "$response" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=');
+    if [ -z "$id" ]; then
+        echo "Error: Failed to get or create release id for tag: $tag";
+        echo "$response" | awk 'length($0)<100' >&2;
+        exit 1
+    fi
+fi
+
+
+# Upload asset
+echo "Uploading asset... "
+
+# Construct url
+GH_ASSET="https://uploads.github.com/repos/$owner/$repo/releases/$id/assets?name=$(basename $filename)"
+
+curl "$GITHUB_OAUTH_BASIC" --data-binary @"$filename" -H "Authorization: token $github_api_token" -H "Content-Type: application/octet-stream" $GH_ASSET


### PR DESCRIPTION
Add artifact uploading to github on tag. #6

This makes the jar version the same as the tag version. In maven we have to keep the version # the same as the presto-spi version we are targeting. I worked around this by just renaming the jar before we upload to github for the tag version.