### PR TITLE
Attribute filtering with TileDB's QueryCondition

### DIFF
--- a/src/main/java/io/trino/plugin/tiledb/TileDBRecordSet.java
+++ b/src/main/java/io/trino/plugin/tiledb/TileDBRecordSet.java
@@ -101,6 +101,12 @@ public class TileDBRecordSet
     @Override
     public RecordCursor cursor()
     {
-        return new TileDBRecordCursor(tileDBClient, session, split, columnHandles, array, query);
+        try {
+            return new TileDBRecordCursor(tileDBClient, session, split, columnHandles, array, query);
+        }
+        catch (TileDBError tileDBError) {
+            tileDBError.printStackTrace();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This implementation takes advantage of the new Query Condition feature in TileDB 2.3.0. Because the QC only offers a limited number of operations this is a hybrid approach. The OR operator and all the predicates (e.g. "LIKE") are still working with the Presto/Trino implementation. The rest use the QC.