### PR TITLE
CI ubuntu image update

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-10.15 ]
+        os: [ ubuntu-latest, macos-10.15 ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR fixes the flakiness that was present when running the CI tests in Ubuntu machines by updating the Ubuntu images that are being used. 
This issue was also mentioned here: [https://github.com/TileDB-Inc/TileDB-Trino/pull/70#issuecomment-847429821](url)

The new update seems to resolve the issue since 5/5 attempts were successful. [https://github.com/TileDB-Inc/TileDB-Trino/actions/runs/2071065042](url)