### PR TITLE
Dstara/bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>io.tiledb</groupId>
             <artifactId>tiledb-java</artifactId>
-            <version>0.12.0</version>
+            <version>0.12.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/trino/plugin/tiledb/TileDBMetadata.java
+++ b/src/main/java/io/trino/plugin/tiledb/TileDBMetadata.java
@@ -73,6 +73,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -166,33 +167,34 @@ public class TileDBMetadata
 
         // Predicates are fetched as summary of constraints
         TupleDomain<ColumnHandle> effectivePredicate = constraint.getSummary();
-        Set<ColumnHandle> columnHandles = new HashSet<>();
-        for (ColumnHandle e : columns.values()) {
-            if (hasPredicate) {
-                columnsWithPredicates.add(e);
-            }
-            //columns that are not included in the columnHandles are filtered by presto, not tileDB. Strings and queries with 'OR' are not pushed down for now.
-            if ((((effectivePredicate.getDomains().get().get(e) != null) &&
-                    (effectivePredicate.getDomains().get().get(e).getValues().getRanges().getOrderedRanges().size() > 1)))) { //having more than one range effectively means it is an OR condition, which is not yet supported by the core library.
-                LOG.info("Column %s has an OR condition which is not yet supported by TileDB's native QueryCondition. The filtering will happen by Trino.", ((TileDBColumnHandle) e).getColumnName());
-            }
-            else if (columnsWithPredicates.contains(e)) { //Predicates are not supported by the QueryCondition, thus we need to leave this to Presto.
-                LOG.info("Column %s uses a Predicate which is not yet supported by TileDB's native QueryCondition. The filtering will happen by Trino.", ((TileDBColumnHandle) e).getColumnName());
-            }
-            else {
-                columnHandles.add(e);
-            }
-        }
+//        Set<ColumnHandle> columnHandles = new HashSet<>(); //TODO check if possible in the future
+//        for (ColumnHandle e : columns.values()) {
+//            if (hasPredicate) {
+//                columnsWithPredicates.add(e);
+//            }
+//            //columns that are not included in the columnHandles are filtered by presto, not tileDB. Strings and queries with 'OR' are not pushed down for now.
+//            if ((((effectivePredicate.getDomains().get().get(e) != null) &&
+//                    (effectivePredicate.getDomains().get().get(e).getValues().getRanges().getOrderedRanges().size() > 1)))) { //having more than one range effectively means it is an OR condition, which is not yet supported by the core library.
+//                LOG.info("Column %s has an OR condition which is not yet supported by TileDB's native QueryCondition. The filtering will happen by Trino.", ((TileDBColumnHandle) e).getColumnName());
+//            }
+//            else if (columnsWithPredicates.contains(e)) { //Predicates are not supported by the QueryCondition, thus we need to leave this to Presto.
+//                LOG.info("Column %s uses a Predicate which is not yet supported by TileDB's native QueryCondition. The filtering will happen by Trino.", ((TileDBColumnHandle) e).getColumnName());
+//            }
+//            else {
+//                columnHandles.add(e);
+//            }
+//        }
 
-//        Uncomment to include all columns
-//        columns that are not included in the columnHandles are filtered by presto, not tileDB
-//        Set<ColumnHandle> columnHandles = new HashSet<>(columns.values());
+        Set<ColumnHandle> dimensionHandles = columns.values().stream()
+                .filter(e -> ((TileDBColumnHandle) e).getIsDimension())
+                .collect(Collectors.toSet());
 
         List<ColumnHandle> columnsInLayout;
         if (desiredColumns.isPresent()) {
             // Add all dimensions since dimensions will always be returned by tiledb
             Set<ColumnHandle> desiredColumnsWithDimension = new HashSet<>(desiredColumns.get());
-            desiredColumnsWithDimension.addAll(columnHandles);
+            desiredColumnsWithDimension.addAll(dimensionHandles);
+//            desiredColumnsWithDimension.addAll(columnHandles);
             columnsInLayout = new ArrayList<>(desiredColumnsWithDimension);
         }
         else {
@@ -200,7 +202,7 @@ public class TileDBMetadata
         }
 
         // The only enforceable constraints are ones for dimension columns
-        Map<ColumnHandle, Domain> enforceableDomains = new HashMap<>(Maps.filterKeys(effectivePredicate.getDomains().get(), Predicates.in(columnHandles)));
+        Map<ColumnHandle, Domain> enforceableDimensionDomains = new HashMap<>(Maps.filterKeys(effectivePredicate.getDomains().get(), Predicates.in(dimensionHandles)));
 
         if (!getSplitOnlyPredicates(session)) {
             try {
@@ -216,9 +218,9 @@ public class TileDBMetadata
                 HashMap<String, Pair> nonEmptyDomain = array.nonEmptyDomain();
                 // Find any dimension which do not have predicates and add one for the entire domain.
                 // This is required so we can later split on the predicates
-                for (ColumnHandle handle : columnHandles) {
-                    if (!enforceableDomains.containsKey(handle)) {
-                        TileDBColumnHandle columnHandle = ((TileDBColumnHandle) handle);
+                for (ColumnHandle dimensionHandle : dimensionHandles) {
+                    if (!enforceableDimensionDomains.containsKey(dimensionHandle)) {
+                        TileDBColumnHandle columnHandle = ((TileDBColumnHandle) dimensionHandle);
                         if (nonEmptyDomain.containsKey(columnHandle.getColumnName())) {
                             Pair<Object, Object> domain = nonEmptyDomain.get(columnHandle.getColumnName());
                             Object nonEmptyMin = domain.getFirst();
@@ -243,8 +245,8 @@ public class TileDBMetadata
                                         ConvertUtils.convert(nonEmptyMax, type.getJavaType()), true);
                             }
 
-                            enforceableDomains.put(
-                                    handle,
+                            enforceableDimensionDomains.put(
+                                    dimensionHandle,
                                     Domain.create(ValueSet.ofRanges(range), false));
                         }
                     }
@@ -256,14 +258,14 @@ public class TileDBMetadata
             }
         }
 
-        TupleDomain<ColumnHandle> enforceableTupleDomain = TupleDomain.withColumnDomains(enforceableDomains);
+        TupleDomain<ColumnHandle> enforceableTupleDomain = TupleDomain.withColumnDomains(enforceableDimensionDomains);
         TupleDomain<ColumnHandle> remainingTupleDomain;
 
         // The remaining tuples non-enforced by TileDB are attributes
-        remainingTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(effectivePredicate.getDomains().get(), Predicates.not(Predicates.in(columnHandles))));
+        remainingTupleDomain = TupleDomain.withColumnDomains(Maps.filterKeys(effectivePredicate.getDomains().get(), Predicates.not(Predicates.in(dimensionHandles))));
 
         ConnectorTableLayout layout = new ConnectorTableLayout(
-                new TileDBTableLayoutHandle(tableHandle, enforceableTupleDomain, columnHandles),
+                new TileDBTableLayoutHandle(tableHandle, enforceableTupleDomain, dimensionHandles),
                 Optional.of(columnsInLayout),
                 TupleDomain.all(),
                 Optional.empty(),

--- a/src/main/java/io/trino/plugin/tiledb/TileDBPageSink.java
+++ b/src/main/java/io/trino/plugin/tiledb/TileDBPageSink.java
@@ -426,9 +426,6 @@ public class TileDBPageSink
         // Only varchar and varbinary are supported for variable length attributes, so we only check these for additional size requirements
         if (type instanceof VarcharType || type instanceof CharType) {
             size = type.getSlice(block, position).toStringUtf8().length();
-            if (size == 0) {
-                size++; // for cases where the empty string is requested
-            }
         }
         else if (VARBINARY.equals(type)) {
             size = type.getSlice(block, position).getBytes().length;

--- a/src/main/java/io/trino/plugin/tiledb/TileDBPageSink.java
+++ b/src/main/java/io/trino/plugin/tiledb/TileDBPageSink.java
@@ -426,6 +426,9 @@ public class TileDBPageSink
         // Only varchar and varbinary are supported for variable length attributes, so we only check these for additional size requirements
         if (type instanceof VarcharType || type instanceof CharType) {
             size = type.getSlice(block, position).toStringUtf8().length();
+            if (size == 0) {
+                size++; // for cases where the empty string is requested
+            }
         }
         else if (VARBINARY.equals(type)) {
             size = type.getSlice(block, position).getBytes().length;

--- a/src/main/java/io/trino/plugin/tiledb/TileDBRecordCursor.java
+++ b/src/main/java/io/trino/plugin/tiledb/TileDBRecordCursor.java
@@ -475,7 +475,7 @@ public class TileDBRecordCursor
             HashMap<String, Attribute> attributes = arraySchema.getAttributes();
             Iterator it = attributes.entrySet().iterator();
             QueryCondition finalQueryCondition = null;
-            while (it.hasNext()) { ////TODO the code below will never be executed since TileDB Query Conditions are disabled for the moment.
+            while (it.hasNext()) { ////TODO the code below will never run since TileDB's Query Condition is disabled at the moment.
                 Map.Entry pair = (Map.Entry) it.next();
                 Attribute att = (Attribute) pair.getValue();
                 Pair attBounds = getBoundsForAttribute(split, att);

--- a/src/test/java/io/trino/plugin/tiledb/TestTileDBQueries.java
+++ b/src/test/java/io/trino/plugin/tiledb/TestTileDBQueries.java
@@ -288,6 +288,25 @@ public class TestTileDBQueries
     }
 
     @Test
+    public void testEmptyString()
+    {
+        String arrayName = "test_empty_string";
+        dropArray(arrayName);
+        create1D2AVector(arrayName);
+
+        String insertSql = format("INSERT INTO %s (x, a1, a2, a3) VALUES " +
+                "(0, 10, '', 300.0), (3, 13, 'b', 200.0), (5, 15, 'c', 1000.0), (6, 16, 'd', 1.0), (7, 124, 'e', 20.0)", arrayName);
+        getQueryRunner().execute(insertSql);
+
+        String selectSql1 = format("SELECT * FROM %s WHERE a2 = '' ", arrayName);
+        MaterializedResult selectResult1 = computeActual(selectSql1);
+        System.out.println(selectResult1);
+        assertEquals(selectResult1, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), BIGINT, INTEGER, VARCHAR, REAL)
+                .row((long) 0, 10, "\u0000", 300.0f)
+                .build());
+    }
+
+    @Test
     public void testCreate1DVectorSmallInt()
     {
         // Smallint


### PR DESCRIPTION
This PR fixes a bug fix related to "count()" queries. However, the main point of this PR is to temporary disable the use of the Query Condition. I discovered some logical errors in the implementation because Trino does not provide enough information from the parser. Thus it is impossible to differentiate between OR and AND and use the QC appropriately. I will come back to this very soon and try a different approach. The code used for the QC is commented. All filtering is now happening in the Trino level. This PR will unblock the CI failures, something which is necessary for updating to TileDB 2.10.X and support the new array format.

The changes in this PR should make the tests run better but the flakiness is still there! This flakiness is probably because of the distributed nature of the connector, however I am not sure. WIP!